### PR TITLE
Make web components form-friendly

### DIFF
--- a/package/index.html
+++ b/package/index.html
@@ -78,7 +78,10 @@
 			</div>
 		</div>
 		<button class="btn" style="width: max-content;">Open search</button>
-		<prism-editor line-numbers language="javascript" theme="github-dark"></prism-editor>
+		<form id="form">
+			<prism-editor name="editor" line-numbers language="javascript" theme="github-dark"></prism-editor>
+			<button class="btn" style="width: max-content;" type="submit">Test sending code as form data</button>
+		</form>
 	</section>
 	<section>
 		<readonly-editor readonly line-numbers language="markdown" theme="github-dark"></readonly-editor>

--- a/package/index.html
+++ b/package/index.html
@@ -80,8 +80,8 @@
 		<button class="btn" style="width: max-content;">Open search</button>
 		<form id="form">
 			<prism-editor name="editor" line-numbers language="javascript" theme="github-dark"></prism-editor>
-			<button class="btn" style="width: max-content;" type="submit">Test sending code as form data</button>
 		</form>
+		<button class="btn" form="form" style="width: max-content;" type="submit">Send as form data</button>
 	</section>
 	<section>
 		<readonly-editor readonly line-numbers language="markdown" theme="github-dark"></readonly-editor>

--- a/package/src/testsite/index.ts
+++ b/package/src/testsite/index.ts
@@ -203,13 +203,13 @@ document.querySelector<HTMLElement>("button.btn")!.onclick = () => {
 	editor2.extensions.searchWidget!.open()
 }
 
-document.querySelector<HTMLFormElement>("#form")!.onsubmit = (e) => {
-	e.preventDefault();
-	const data = new FormData(e.target as HTMLFormElement);
+document.querySelector<HTMLFormElement>("#form")!.onsubmit = e => {
+	e.preventDefault()
+	const data = new FormData(e.target as HTMLFormElement)
 	console.info(`===
 Form submission results:
 ===
-${data.get('editor')}`);
+${data.get("editor")}`)
 }
 
 setTimeout(() => import("../prism/languages"), 500)

--- a/package/src/testsite/index.ts
+++ b/package/src/testsite/index.ts
@@ -205,7 +205,7 @@ document.querySelector<HTMLElement>("button.btn")!.onclick = () => {
 
 document.querySelector<HTMLFormElement>("#form")!.onsubmit = (e) => {
 	e.preventDefault();
-	const data = new FormData(e.target);
+	const data = new FormData(e.target as HTMLFormElement);
 	console.info(`===
 Form submission results:
 ===

--- a/package/src/testsite/index.ts
+++ b/package/src/testsite/index.ts
@@ -203,4 +203,13 @@ document.querySelector<HTMLElement>("button.btn")!.onclick = () => {
 	editor2.extensions.searchWidget!.open()
 }
 
+document.querySelector<HTMLFormElement>("#form")!.onsubmit = (e) => {
+	e.preventDefault();
+	const data = new FormData(e.target);
+	console.info(`===
+Form submission results:
+===
+${data.get('editor')}`);
+}
+
 setTimeout(() => import("../prism/languages"), 500)

--- a/package/src/webComponent.ts
+++ b/package/src/webComponent.ts
@@ -44,11 +44,13 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 
 			constructor() {
 				super()
-				const internals = this.attachInternals()
+				const internals = this.attachInternals?.()
 				this.editor = createEditor(this, getOptions(this), () =>
 					this.dispatchEvent(new CustomEvent("ready")),
 				)
-				this.editor.addListener("update", internals.setFormValue.bind(internals))
+				if (internals) {
+					this.editor.addListener("update", internals.setFormValue.bind(internals))
+				}
 
 				for (const attr in attributeMap)
 					Object.defineProperty(this, attributeMap[<keyof typeof attributeMap>attr][1] || attr, {
@@ -65,6 +67,10 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 			}
 			set value(value: string) {
 				this.editor.setOptions({ value })
+			}
+
+			formResetCallback() {
+				this.value = this.editor.options.value
 			}
 
 			attributeChangedCallback(

--- a/package/src/webComponent.ts
+++ b/package/src/webComponent.ts
@@ -41,14 +41,14 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 			static formAssociated = true
 
 			editor: PrismEditor
-			internals: ElementInternals
 
 			constructor() {
 				super()
-				this.internals = this.attachInternals()
+				const internals = this.attachInternals()
 				this.editor = createEditor(this, getOptions(this), () =>
 					this.dispatchEvent(new CustomEvent("ready")),
 				)
+				this.editor.addListener("update", internals.setFormValue.bind(internals))
 
 				for (const attr in attributeMap)
 					Object.defineProperty(this, attributeMap[<keyof typeof attributeMap>attr][1] || attr, {
@@ -65,14 +65,6 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 			}
 			set value(value: string) {
 				this.editor.setOptions({ value })
-				this.internals.setFormValue(this.editor.value);
-			}
-
-			formAssociatedCallback() {
-				setTimeout(
-					() => this.internals.setFormValue(this.editor.value),
-					200
-				)
 			}
 
 			attributeChangedCallback(

--- a/package/src/webComponent.ts
+++ b/package/src/webComponent.ts
@@ -38,10 +38,14 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 		name,
 		class extends HTMLElement {
 			static observedAttributes = attributes
+			static formAssociated = true
+
 			editor: PrismEditor
+			internals: ElementInternals
 
 			constructor() {
 				super()
+				this.internals = this.attachInternals()
 				this.editor = createEditor(this, getOptions(this), () =>
 					this.dispatchEvent(new CustomEvent("ready")),
 				)
@@ -61,6 +65,14 @@ const addComponent = (name: string, createEditor: typeof basicEditor) => {
 			}
 			set value(value: string) {
 				this.editor.setOptions({ value })
+				this.internals.setFormValue(this.editor.value);
+			}
+
+			formAssociatedCallback() {
+				setTimeout(
+					() => this.internals.setFormValue(this.editor.value),
+					200
+				)
 			}
 
 			attributeChangedCallback(


### PR DESCRIPTION
## Intent

This changeset turns the editor web components into form-associated custom elements, allowing them to work as native form inputs would.