### PR TITLE
Fix languages export

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -26,10 +26,26 @@
     "./code-block.css": "./dist/code-block.css",
     "./themes/*.css": "./dist/themes/*.css",
     "./themes": "./dist/themes/index.js",
-    "./languages": "./dist/languages/index.js",
-    "./languages/*": "./dist/languages/*.js",
-    "./prism/languages": "./dist/prism/languages/index.js",
-    "./prism/languages/*": "./dist/prism/languages/*.js",
+    "./languages": {
+      "types": "./dist/languages/index.d.ts",
+      "import": "./dist/languages/index.js",
+      "default": "./dist/languages/index.js"
+    },
+    "./languages/*": {
+      "types": "./dist/languages/*.d.ts",
+      "import": "./dist/languages/*.js",
+      "default": "./dist/languages/*.js"
+    },
+    "./prism/languages": {
+      "types": "./dist/prism/languages/index.d.ts",
+      "import": "./dist/prism/languages/index.js",
+      "default": "./dist/prism/languages/index.js"
+    },
+    "./prism/languages/*": {
+      "types": "./dist/prism/languages/*.d.ts",
+      "import": "./dist/prism/languages/*.js",
+      "default": "./dist/prism/languages/*.js"
+    },
     "./match-brackets": "./dist/extensions/matchBrackets/index.js",
     "./highlight-brackets": "./dist/extensions/matchBrackets/highlight.js",
     "./match-tags": "./dist/extensions/matchTags.js",

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -296,7 +296,8 @@ const numLines = (str: string, start = 0, end = Infinity) => {
 }
 
 /** Object storing all language specific behavior. */
-const languageMap: Record<string, Language> = {}
+const languageMap: Record<string, Language> =
+	((globalThis as any)[Symbol.for("prism-code-editor.languageMap")] ||= {})
 
 const editorTemplate = /* @__PURE__ */ createTemplate(
 	"<div><div class=pce-wrapper><div class=pce-overlays><textarea class=pce-textarea spellcheck=false autocapitalize=off autocomplete=off>",

--- a/package/src/prism/core.js
+++ b/package/src/prism/core.js
@@ -1,19 +1,25 @@
 // Slimmed down Prism core with most high level functions removed
 
-var plainTextGrammar = {};
-var rest = Symbol();
-var tokenize = Symbol();
+var globalKey = Symbol.for("prism-code-editor.prism");
+var prismGlobal = globalThis[globalKey] || (globalThis[globalKey] = {});
+
+var plainTextGrammar = prismGlobal.plainTextGrammar || (prismGlobal.plainTextGrammar = {});
+var rest = prismGlobal.rest || (prismGlobal.rest = Symbol.for("prism-code-editor.prism.rest"));
+var tokenize =
+	prismGlobal.tokenize || (prismGlobal.tokenize = Symbol.for("prism-code-editor.prism.tokenize"));
 
 /** @param {*} id */
 var resolve = id => typeof id == 'string' ? languages[id] : id;
 
 /** @type {Record<string, any>} */
-var languages = {
-	plain: plainTextGrammar,
-	plaintext: plainTextGrammar,
-	text: plainTextGrammar,
-	txt: plainTextGrammar,
-};
+var languages =
+	prismGlobal.languages ||
+	(prismGlobal.languages = {
+		plain: plainTextGrammar,
+		plaintext: plainTextGrammar,
+		text: plainTextGrammar,
+		txt: plainTextGrammar,
+	});
 
 /**
  * @param {string} text

--- a/package/src/prism/core.js
+++ b/package/src/prism/core.js
@@ -1,20 +1,19 @@
 // Slimmed down Prism core with most high level functions removed
 
 var globalKey = Symbol.for("prism-code-editor.prism");
-var prismGlobal = globalThis[globalKey] || (globalThis[globalKey] = {});
+var prismGlobal = (globalThis[globalKey] ||= {});
 
-var plainTextGrammar = prismGlobal.plainTextGrammar || (prismGlobal.plainTextGrammar = {});
-var rest = prismGlobal.rest || (prismGlobal.rest = Symbol.for("prism-code-editor.prism.rest"));
+var plainTextGrammar = (prismGlobal.plainTextGrammar ||= {});
+var rest = (prismGlobal.rest ||= Symbol.for("prism-code-editor.prism.rest"));
 var tokenize =
-	prismGlobal.tokenize || (prismGlobal.tokenize = Symbol.for("prism-code-editor.prism.tokenize"));
+	(prismGlobal.tokenize ||= Symbol.for("prism-code-editor.prism.tokenize"));
 
 /** @param {*} id */
 var resolve = id => typeof id == 'string' ? languages[id] : id;
 
 /** @type {Record<string, any>} */
 var languages =
-	prismGlobal.languages ||
-	(prismGlobal.languages = {
+	(prismGlobal.languages ||= {
 		plain: plainTextGrammar,
 		plaintext: plainTextGrammar,
 		text: plainTextGrammar,


### PR DESCRIPTION
Close #57

## Suggested Approach

Currently, the output entries cannot share the same global objects when used through an ESM CDN.

So the library works with a normal static/bundled build, but it is not usable reliably with `<script type="module">` in HTML via CDN imports.

For example:

```js
import { languages } from "prism-code-editor/prism";
import "prism-code-editor/prism/languages/bash.js";
````

The `bash` language may be registered into a different `languages` object from the one imported from `prism-code-editor/prism`.

To fix it:

1. Add exports in each language module.
2. Add `types`, `import`, and `default` in `package.json` exports instead of only pointing to `.js`.
3. Use `Symbol.for("prism-code-editor.languageMap")` and similar global keys for Prism languages, so different ESM entries can share the same global objects.

## Alternative Approach (not this PR)

Another approach is to create explicit ESM exports for the shared objects, instead of keeping them as local `var xxx`.

For example:

```ts
// global.ts
export const plainTextGrammar: Record<string, unknown> = {};
export const rest = Symbol();
export const tokenize = Symbol();

export const languages: Record<string, unknown> = {
  plain: plainTextGrammar,
  plaintext: plainTextGrammar,
  text: plainTextGrammar,
  txt: plainTextGrammar,
};
```

Then other scripts can import from it:

```ts
import { plainTextGrammar, rest, tokenize, languages } from "./global";
```

This would make all ESM modules refer to the same exported objects within the same build.

However, for CDN usage, different entries can still be transformed separately. So using `Symbol.for(...)` should be safer for this package.

## Conclusion

Using local `var xxx` registries with ESM CDN entry points can cause duplicated registry objects.

This PR makes the registries shared across entries, while keeping the existing side-effect import API.

---

## Verification

This was verified with:

```html
<script type="importmap">
{
  "imports": {
    "prism-code-editor": "https://esm.sh/@cyfung1031/prism-code-editor@5.2.0-cdn-esm.1",
    "prism-code-editor/": "https://esm.sh/@cyfung1031/prism-code-editor@5.2.0-cdn-esm.1/"
  }
}
</script>
```

```html
<script type="module">
  import { basicEditor, readonlyEditor } from "prism-code-editor/setups";
  import { languages } from "prism-code-editor/prism";
  import "prism-code-editor/prism/languages/bash.js";

  const bashGrammar = languages.bash || languages.sh || languages.shell;
  console.log("Bash grammar loaded:", !!bashGrammar, bashGrammar);
</script>
```

---

## Actual Use

https://mac-tool.github.io/scripts
