### PR TITLE
Fix edge case in tokenizer generating invalid html

### DIFF
--- a/package/src/prism/core.js
+++ b/package/src/prism/core.js
@@ -71,14 +71,12 @@ var stringify = token => {
 		var { type, alias, content } = token;
 		var prevOpening = openingTags;
 		var prevClosing = closingTags;
-
-		var keywordClass = '';
-		if (type == 'keyword' && typeof content == 'string') {
-			keywordClass += ' keyword-';
-			keywordClass += content.replace(/"|\n/g, '');
-		}
-
-		var opening = `<span class="token ${ type + (alias ? ' ' + alias : '') + keywordClass }">`;
+		var opening = `<span class="token ${
+			type + (alias ? ' ' + alias : '') +
+			(type == 'keyword' && typeof content == 'string'
+				? ' keyword-' + content.replace(/"|\s/g, '')
+				: '')
+		}">`;
 		closingTags += closingTag;
 		openingTags += opening;
 		var contentStr = stringify(content);

--- a/package/src/prism/core.js
+++ b/package/src/prism/core.js
@@ -72,14 +72,13 @@ var stringify = token => {
 		var prevOpening = openingTags;
 		var prevClosing = closingTags;
 
-		var openingClasses = ['token', type];
-		if (alias) openingClasses.push(alias);
+		var keywordClass = '';
 		if (type == 'keyword' && typeof content == 'string') {
-			openingClasses.push('keyword-' + content.replace(/[^a-z0-9]/gi, ''));
+			keywordClass += ' keyword-';
+			keywordClass += content.replace(/"|\n/g, '');
 		}
 
-		var opening = `<span class="${openingClasses.join(' ')}">`;
-
+		var opening = `<span class="token ${ type + (alias ? ' ' + alias : '') + keywordClass }">`;
 		closingTags += closingTag;
 		openingTags += opening;
 		var contentStr = stringify(content);

--- a/package/src/prism/core.js
+++ b/package/src/prism/core.js
@@ -71,10 +71,14 @@ var stringify = token => {
 		var { type, alias, content } = token;
 		var prevOpening = openingTags;
 		var prevClosing = closingTags;
-		var opening = `<span class="token ${
-			type + (alias ? ' ' + alias : '') +
-			(type == 'keyword' && typeof content == 'string' ? ' keyword-' + content : '')
-		}">`;
+
+		var openingClasses = ['token', type];
+		if (alias) openingClasses.push(alias);
+		if (type == 'keyword' && typeof content == 'string') {
+			openingClasses.push('keyword-' + content.replace(/[^a-z0-9]/gi, ''));
+		}
+
+		var opening = `<span class="${openingClasses.join(' ')}">`;
 
 		closingTags += closingTag;
 		openingTags += opening;

--- a/package/src/prism/languages/nasm.js
+++ b/package/src/prism/languages/nasm.js
@@ -11,7 +11,7 @@ languages.nasm = {
 	'keyword': [
 		/\[?BITS (?:16|32|64)\]?/,
 		{
-			pattern: /(^\s*)section\s*[a-z.]+:?/im,
+			pattern: /(^\s*)section[^\S\n]*[a-z.]+:?/im,
 			lookbehind: true
 		},
 		/(?:extern|global)[^\n;]*/i,

--- a/package/src/prism/languages/nasm.js
+++ b/package/src/prism/languages/nasm.js
@@ -11,7 +11,7 @@ languages.nasm = {
 	'keyword': [
 		/\[?BITS (?:16|32|64)\]?/,
 		{
-			pattern: /(^\s*)section[^\S\n]*[a-z.]+:?/im,
+			pattern: /(^\s*)section[\t ]*[a-z.]+:?/im,
 			lookbehind: true
 		},
 		/(?:extern|global)[^\n;]*/i,


### PR DESCRIPTION

This MR fixes an interesting edge cases that was causing the editor to crash when using the nasm syntax.

To reproduce:
Open the editor in in nasm sytax mode, and write:

```nasm
section
any text
```

The editor will either crash, or cause the sytax-colored text to disappear.

This is caused by two separate issues:

1: The nasm grammar rules can create broken "section" Tokens with a
   newline in the token.content. This happens when text contains "section" followed by a newline, instead of the expected "section my_section_name"

2: Token.stringify returns an html string with the token.content unsafely
   injected in the html tag. If token.content contains html or newlines
   the returned string will be malformed.


---

I would also use this opportunity to thank you for this amazing project. The design choices behind it are incredibly clean, and It has saved me a lot of work